### PR TITLE
escape the space

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -6,8 +6,8 @@ With this bundle you can easily view the archives, see list info and Unsubscribe
 # Installation
 
 ```
-mkdir -p ~/Library/Application Support/MailMate/Bundles
-cd ~/Library/Application Support/MailMate/Bundles
+mkdir -p ~/Library/Application\ Support/MailMate/Bundles
+cd ~/Library/Application\ Support/MailMate/Bundles
 git clone https://github.com/maxandersen/listMate.mmBundle
 ```
 


### PR DESCRIPTION
escape the space in the path so that copy and paste of commands does the right thing. i copied and pasted without the \ and it definitely did not do the right thing ;-)
